### PR TITLE
fix: fallback font handling for figlet

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -16,7 +16,6 @@
         "gradient-string": "^3.0.0",
         "inquirer": "^12.6.3",
         "ora": "^8.2.0",
-        "release-it": "^19.0.3",
       },
       "devDependencies": {
         "@antfu/eslint-config": "^4.13.2",
@@ -25,7 +24,10 @@
         "@types/inquirer": "^9.0.8",
         "eslint": "^9.28.0",
         "eslint-plugin-format": "^1.0.1",
+        "only-allow": "^1.2.1",
         "prettier": "^3.5.3",
+        "release-it": "^19.0.3",
+        "rimraf": "^6.0.1",
       },
       "peerDependencies": {
         "typescript": "^5.7.3",
@@ -140,6 +142,8 @@
     "@inquirer/select": ["@inquirer/select@4.2.3", "", { "dependencies": { "@inquirer/core": "^10.1.13", "@inquirer/figures": "^1.0.12", "@inquirer/type": "^3.0.7", "ansi-escapes": "^4.3.2", "yoctocolors-cjs": "^2.1.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-OAGhXU0Cvh0PhLz9xTF/kx6g6x+sP+PcyTiLvCrewI99P3BBeexD+VbuwkNDvqGkk3y2h5ZiWLeRP7BFlhkUDg=="],
 
     "@inquirer/type": ["@inquirer/type@3.0.7", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-PfunHQcjwnju84L+ycmcMKB/pTPIngjUJvfnRhKY6FKPuYXlM4aQCb/nIdTFR6BEhMjFvngzvng/vBAJMZpLSA=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
@@ -409,6 +413,8 @@
 
     "dotenv": ["dotenv@16.5.0", "", {}, "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg=="],
 
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.161", "", {}, "sha512-hwtetwfKNZo/UlwHIVBlKZVdy7o8bIZxxKs0Mv/ROPiQQQmDgdm5a+KvKtBsxM8ZjFzTaCeLoodZ8jiBE3o9rA=="],
 
     "emoji-regex": ["emoji-regex@10.4.0", "", {}, "sha512-EC+0oUMY1Rqm4O6LLrgjtYDvcVYTy7chDnM4Q7030tP4Kwj3u/pR6gP9ygnp2CJMK5Gq+9Q2oqmrFJAz01DXjw=="],
@@ -535,6 +541,8 @@
 
     "flatted": ["flatted@3.3.3", "", {}, "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg=="],
 
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
     "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.3.0", "", {}, "sha512-vpeMIQKxczTD/0s2CdEWHcb0eeJe6TFjxb+J5xgX7hScxqrGuyjmv4c1D4A/gelKfyox0gJJwIHF+fLjeaM8kQ=="],
@@ -550,6 +558,8 @@
     "git-up": ["git-up@8.1.1", "", { "dependencies": { "is-ssh": "^1.4.0", "parse-url": "^9.2.0" } }, "sha512-FDenSF3fVqBYSaJoYy1KSc2wosx0gCvKP+c+PRBht7cAaiCeQlBtfBDX9vgnNOHmdePlSFITVcn4pFfcgNvx3g=="],
 
     "git-url-parse": ["git-url-parse@16.1.0", "", { "dependencies": { "git-up": "^8.1.0" } }, "sha512-cPLz4HuK86wClEW7iDdeAKcCVlWXmrLpb2L+G9goW0Z1dtpNS6BXXSOckUTlJT/LDQViE1QZKstNORzHsLnobw=="],
+
+    "glob": ["glob@11.0.2", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^4.0.1", "minimatch": "^10.0.0", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-YT7U7Vye+t5fZ/QMkBFrTJ7ZQxInIUjwyAjVj84CYXqgBdv30MFUPGnBR6sQaVq6Is15wYJUsnzTuWaGRBhBAQ=="],
 
     "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
 
@@ -610,6 +620,8 @@
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "issue-parser": ["issue-parser@7.0.1", "", { "dependencies": { "lodash.capitalize": "^4.2.1", "lodash.escaperegexp": "^4.1.2", "lodash.isplainobject": "^4.0.6", "lodash.isstring": "^4.0.1", "lodash.uniqby": "^4.7.0" } }, "sha512-3YZcUUR2Wt1WsapF+S/WiA2WmlW0cWAoPccMqne7AxEBhCdFeTPjfv/Axb8V2gyCgY3nRw+ksZ3xSUX+R47iAg=="],
+
+    "jackspeak": ["jackspeak@4.1.1", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" } }, "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ=="],
 
     "jiti": ["jiti@2.4.2", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A=="],
 
@@ -769,6 +781,8 @@
 
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
+    "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
+
     "mlly": ["mlly@1.7.4", "", { "dependencies": { "acorn": "^8.14.0", "pathe": "^2.0.1", "pkg-types": "^1.3.0", "ufo": "^1.5.4" } }, "sha512-qmdSIPC4bDJXgZTCR7XosJiNKySV7O215tsPtDN9iEO/7q/76b/ijtgRu/+epFXSJhijtTCCGp3DWS549P3xKw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
@@ -801,6 +815,8 @@
 
     "onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
 
+    "only-allow": ["only-allow@1.2.1", "", { "dependencies": { "which-pm-runs": "^1.1.0" }, "bin": { "only-allow": "bin.js" } }, "sha512-M7CJbmv7UCopc0neRKdzfoGWaVZC+xC1925GitKH9EAqYFzX9//25Q7oX4+jw0tiCCj+t5l6VZh8UPH23NZkMA=="],
+
     "open": ["open@10.1.2", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "is-wsl": "^3.1.0" } }, "sha512-cxN6aIDPz6rm8hbebcP7vrQNhvRcveZoJU72Y7vskh4oIm+BZwBECnx5nTmrlres1Qapvx27Qo1Auukpf8PKXw=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
@@ -819,6 +835,8 @@
 
     "pac-resolver": ["pac-resolver@7.0.1", "", { "dependencies": { "degenerator": "^5.0.0", "netmask": "^2.0.2" } }, "sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg=="],
 
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
     "package-manager-detector": ["package-manager-detector@1.3.0", "", {}, "sha512-ZsEbbZORsyHuO00lY1kV3/t72yp6Ysay6Pd17ZAlNGuGwmWDLCJxFpRs0IzfXfj1o4icJOkUEioexFHzyPurSQ=="],
 
     "parent-module": ["parent-module@1.0.1", "", { "dependencies": { "callsites": "^3.0.0" } }, "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g=="],
@@ -836,6 +854,8 @@
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@2.0.0", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -899,6 +919,8 @@
 
     "reusify": ["reusify@1.1.0", "", {}, "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw=="],
 
+    "rimraf": ["rimraf@6.0.1", "", { "dependencies": { "glob": "^11.0.0", "package-json-from-dist": "^1.0.0" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-9dkvaxAsk/xNXSJzMgFqqMCuFgt2+KsOFek3TMLfo8NCPfWpBmqwyNn5Y+NX56QUYfCtsyhF3ayiboEoUmJk/A=="],
+
     "run-applescript": ["run-applescript@7.0.0", "", {}, "sha512-9by4Ij99JUr/MCFBUkDKLWK3G9HVXmabKz9U5MlIAIuvuzkiOicRYs8XJLxX+xahD+mLiiCYDqF9dKAgtzKP1A=="],
 
     "run-async": ["run-async@3.0.0", "", {}, "sha512-540WwVDOMxA6dN6We19EcT9sc3hkXPw5mzRNGM3FkdN/vtE9NFvj5lFAPNwUDmJjXidm3v7TC1cTE7t17Ulm1Q=="],
@@ -947,7 +969,11 @@
 
     "string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
 
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
     "strip-ansi": ["strip-ansi@7.1.0", "", { "dependencies": { "ansi-regex": "^6.0.1" } }, "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "strip-final-newline": ["strip-final-newline@3.0.0", "", {}, "sha512-dOESqjYr96iWYylGObzd39EuNTa5VJxyvVAEm5Jnh7KGo75V43Hk1odPQkNDyXNmUR6k+gEiDVXnjB8HJ3crXw=="],
 
@@ -987,7 +1013,7 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
-    "type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
+    "type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
 
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
@@ -1023,6 +1049,8 @@
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
+    "which-pm-runs": ["which-pm-runs@1.1.0", "", {}, "sha512-n1brCuqClxfFfq/Rb0ICg9giSZqCS+pLtccdag6C2HyufBrh3fBOiy9nb6ggRMvWOVH5GrdJskj5iGTZNxd7SA=="],
+
     "wildcard-match": ["wildcard-match@5.1.4", "", {}, "sha512-wldeCaczs8XXq7hj+5d/F38JE2r7EXgb6WQDM84RVwxy81T/sxB5e9+uZLK9Q9oNz1mlvjut+QtvgaOQFPVq/g=="],
 
     "windows-release": ["windows-release@6.1.0", "", { "dependencies": { "execa": "^8.0.1" } }, "sha512-1lOb3qdzw6OFmOzoY0nauhLG72TpWtb5qgYPiSh/62rjc1XidBSDio2qw0pwHh17VINF217ebIkZJdFLZFn9SA=="],
@@ -1030,6 +1058,8 @@
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
     "wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
     "xml-name-validator": ["xml-name-validator@4.0.0", "", {}, "sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw=="],
 
@@ -1059,6 +1089,10 @@
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
 
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@isaacs/cliui/wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
     "@octokit/plugin-paginate-rest/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
 
     "@octokit/plugin-rest-endpoint-methods/@octokit/types": ["@octokit/types@13.10.0", "", { "dependencies": { "@octokit/openapi-types": "^24.2.0" } }, "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA=="],
@@ -1066,6 +1100,8 @@
     "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "ansi-escapes/type-fest": ["type-fest@0.21.3", "", {}, "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="],
 
     "clean-regexp/escape-string-regexp": ["escape-string-regexp@1.0.5", "", {}, "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg=="],
 
@@ -1087,6 +1123,8 @@
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "glob/minimatch": ["minimatch@10.0.1", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-ethXTt3SGGR+95gudmqJ1eNhRO7eGEGIgYA9vnPatK4/etz2MEVDno5GMCibdMTuBMyElzIlgxMna3K94XDIDQ=="],
+
     "jsonc-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "jsonc-eslint-parser/espree": ["espree@9.6.1", "", { "dependencies": { "acorn": "^8.9.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^3.4.1" } }, "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ=="],
@@ -1101,15 +1139,21 @@
 
     "mlly/pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
 
-    "new-github-release-url/type-fest": ["type-fest@2.19.0", "", {}, "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA=="],
-
     "npm-run-path/path-key": ["path-key@4.0.0", "", {}, "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ=="],
 
     "nypm/tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
 
+    "path-scurry/lru-cache": ["lru-cache@11.1.0", "", {}, "sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A=="],
+
     "postcss/nanoid": ["nanoid@3.3.11", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "regjsparser/jsesc": ["jsesc@3.0.2", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-xKqzzWXDttJuOcawBt4KnKHHIf5oQ/Cxax+0PWFG+DFDgHNAdi+TXECADI+RYiFUMmx8792xsMbbgXj4CwnP4g=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "toml-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1117,9 +1161,17 @@
 
     "wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
     "yaml-eslint-parser/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
     "@eslint/markdown/@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.13.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@isaacs/cliui/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "@octokit/plugin-paginate-rest/@octokit/types/@octokit/openapi-types": ["@octokit/openapi-types@24.2.0", "", {}, "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg=="],
 
@@ -1135,7 +1187,15 @@
 
     "eslint-plugin-unicorn/@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.13.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-yfkgDw1KR66rkT5A8ci4irzDysN7FRpq3ttJolR88OqQikAWqwA8j5VZyas+vjyBNFIJ7MfybJ9plMILI2UrCw=="],
 
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
     "mlly/pkg-types/confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "wrap-ansi/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "build:dts": "tsc --emitDeclarationOnly --declaration --noEmit false --outDir dist --project ./tsconfig.json",
     "build:main": "bun build src/index.ts --outdir dist --target node --format esm --minify",
     "build:cli": "bun build src/cli.ts --outdir dist --target node --format esm --minify && node -e \"const fs=require('fs');const f='dist/cli.js';const c=fs.readFileSync(f,'utf8');if(!c.startsWith('#!/usr/bin/env node'))fs.writeFileSync(f,'#!/usr/bin/env node\\\\n'+c)\"",
-    "postbuild": "chmod +x dist/cli.js",
     "start:dev": "bun --bun run src/index.ts",
     "start:cli:dev": "bun --bun run src/cli.ts",
     "prepublish:next": "bun run build",
@@ -70,12 +69,14 @@
   "devDependencies": {
     "@antfu/eslint-config": "^4.13.2",
     "@types/bun": "latest",
-    "@types/inquirer": "^9.0.8",
     "@types/figlet": "^1.7.0",
+    "@types/inquirer": "^9.0.8",
     "eslint": "^9.28.0",
     "eslint-plugin-format": "^1.0.1",
+    "only-allow": "^1.2.1",
     "prettier": "^3.5.3",
-    "release-it": "^19.0.3"
+    "release-it": "^19.0.3",
+    "rimraf": "^6.0.1"
   },
   "peerDependencies": {
     "typescript": "^5.7.3"

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,8 +12,8 @@ import { presetManager } from "./presets.js";
 import type { PresetParameter, Preset } from "./presets.js";
 import figlet from "figlet";
 import { vice } from "gradient-string";
-import { writeFileSync, mkdirSync, existsSync } from "fs";
-import { join } from "path";
+import fs, { writeFileSync, mkdirSync, existsSync } from "fs";
+import path, { join } from "path";
 import { homedir } from "os";
 import packageJSON from "../package.json" assert { type: "json" };
 import inquirer from "inquirer";
@@ -26,7 +26,7 @@ program
   .version(packageJSON.version, "--version", "Show version information")
   .option(
     "-m, --model <model>",
-    "AI model to use (openai, claude, gemini, grok)",
+    "AI model to use (openai, claude, gemini, grok)"
   )
   .option("-p, --provider <provider>", "Model provider specific variant")
   .option("-c, --copy", "Copy command to clipboard")
@@ -72,7 +72,7 @@ program
         } catch (error) {
           console.log(
             chalk.red("\n✗ Failed to copy to clipboard:"),
-            (error as Error).message,
+            (error as Error).message
           );
         }
       }
@@ -132,8 +132,8 @@ program
       console.log(chalk.gray(`   Location: ${configFile}`));
       console.log(
         chalk.gray(
-          "\n   Use --force flag to overwrite the existing configuration.",
-        ),
+          "\n   Use --force flag to overwrite the existing configuration."
+        )
       );
       process.exit(1);
     }
@@ -144,12 +144,12 @@ program
         mkdirSync(configPath, { recursive: true });
         console.log(
           chalk.green("✓ Created directory:"),
-          chalk.gray(configPath),
+          chalk.gray(configPath)
         );
       } catch (error) {
         console.error(
           chalk.red("Failed to create directory:"),
-          (error as Error).message,
+          (error as Error).message
         );
         process.exit(1);
       }
@@ -181,17 +181,17 @@ program
       writeFileSync(configFile, JSON.stringify(sampleConfig, null, 2));
       console.log(
         chalk.green("✓ Created configuration file:"),
-        chalk.gray(configFile),
+        chalk.gray(configFile)
       );
 
       console.log(chalk.cyan("\n📝 Sample configuration created!"));
       console.log(chalk.bold("\nNext steps:"));
       console.log(
-        chalk.gray("1. Edit the configuration file to add your API keys:"),
+        chalk.gray("1. Edit the configuration file to add your API keys:")
       );
       console.log(chalk.white(`   ${configFile}`));
       console.log(
-        chalk.gray("\n2. Or use the config command to set API keys:"),
+        chalk.gray("\n2. Or use the config command to set API keys:")
       );
       console.log(chalk.white("   llmpeg config --openai YOUR_KEY"));
       console.log(chalk.white("   llmpeg config --claude YOUR_KEY"));
@@ -204,7 +204,7 @@ program
     } catch (error) {
       console.error(
         chalk.red("Failed to create configuration file:"),
-        (error as Error).message,
+        (error as Error).message
       );
       process.exit(1);
     }
@@ -219,16 +219,16 @@ program
   .option("--grok <key>", "Set Grok API key")
   .option(
     "--default-provider <provider>",
-    "Set default AI provider (openai, claude, gemini, grok)",
+    "Set default AI provider (openai, claude, gemini, grok)"
   )
   .option(
     "--default-model <model>",
-    "Set default model for the current provider",
+    "Set default model for the current provider"
   )
   .option("--show", "Show current configuration (keys are masked)")
   .option(
     "--auto-copy <value>",
-    "Enable/disable automatic clipboard copy (true/false)",
+    "Enable/disable automatic clipboard copy (true/false)"
   )
   .action(async (options) => {
     if (options.show) {
@@ -239,43 +239,43 @@ program
       console.log(chalk.bold("API Keys:"));
       console.log(
         "  OpenAI:",
-        config.openai?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set"),
+        config.openai?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set")
       );
       console.log(
         "  Claude:",
-        config.claude?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set"),
+        config.claude?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set")
       );
       console.log(
         "  Gemini:",
-        config.gemini?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set"),
+        config.gemini?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set")
       );
       console.log(
         "  Grok:",
-        config.grok?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set"),
+        config.grok?.apiKey ? chalk.green("✓ Set") : chalk.red("✗ Not set")
       );
 
       console.log(chalk.bold("\nDefaults:"));
       console.log(
         "  Default Provider:",
-        chalk.yellow(config.defaultProvider || "openai"),
+        chalk.yellow(config.defaultProvider || "openai")
       );
 
       if (config.openai?.defaultModel) {
         console.log(
           "  OpenAI Model:",
-          chalk.yellow(config.openai.defaultModel),
+          chalk.yellow(config.openai.defaultModel)
         );
       }
       if (config.claude?.defaultModel) {
         console.log(
           "  Claude Model:",
-          chalk.yellow(config.claude.defaultModel),
+          chalk.yellow(config.claude.defaultModel)
         );
       }
       if (config.gemini?.defaultModel) {
         console.log(
           "  Gemini Model:",
-          chalk.yellow(config.gemini.defaultModel),
+          chalk.yellow(config.gemini.defaultModel)
         );
       }
       if (config.grok?.defaultModel) {
@@ -291,7 +291,7 @@ program
       console.log(chalk.bold("\nSettings:"));
       console.log(
         "  Auto-copy:",
-        config.autoCopy ? chalk.green("✓ Enabled") : chalk.gray("✗ Disabled"),
+        config.autoCopy ? chalk.green("✓ Enabled") : chalk.gray("✗ Disabled")
       );
       return;
     }
@@ -318,10 +318,10 @@ program
       const validProviders = ["openai", "claude", "gemini", "grok"];
       if (!validProviders.includes(options.defaultProvider.toLowerCase())) {
         console.error(
-          chalk.red(`Invalid provider: ${options.defaultProvider}`),
+          chalk.red(`Invalid provider: ${options.defaultProvider}`)
         );
         console.error(
-          chalk.gray(`Valid providers: ${validProviders.join(", ")}`),
+          chalk.gray(`Valid providers: ${validProviders.join(", ")}`)
         );
         process.exit(1);
       }
@@ -333,8 +333,8 @@ program
       configManager.setDefaultModel(currentProvider, options.defaultModel);
       console.log(
         chalk.gray(
-          `Set default model for ${currentProvider}: ${options.defaultModel}`,
-        ),
+          `Set default model for ${currentProvider}: ${options.defaultModel}`
+        )
       );
       updated = true;
     }
@@ -348,7 +348,7 @@ program
     if (updated) {
       await configManager.save();
       console.log(
-        chalk.green("✓ Configuration saved to ~/.llmpeg/config.json"),
+        chalk.green("✓ Configuration saved to ~/.llmpeg/config.json")
       );
     } else {
       console.log(chalk.yellow("No configuration changes made."));
@@ -408,7 +408,7 @@ program
       console.log(`\nCommands today: ${chalk.bold(stats.commandsToday)}`);
       console.log(`Commands this week: ${chalk.bold(stats.commandsThisWeek)}`);
       console.log(
-        `Commands this month: ${chalk.bold(stats.commandsThisMonth)}`,
+        `Commands this month: ${chalk.bold(stats.commandsThisMonth)}`
       );
       return;
     }
@@ -462,11 +462,11 @@ program
         entry.tags.length > 0 ? chalk.gray(` [${entry.tags.join(", ")}]`) : "";
 
       console.log(
-        `${favorite} ${chalk.bold(`${index + 1}.`)} ${chalk.cyan(entry.prompt)}${tags}`,
+        `${favorite} ${chalk.bold(`${index + 1}.`)} ${chalk.cyan(entry.prompt)}${tags}`
       );
       console.log(`   ${chalk.green(entry.command)}`);
       console.log(
-        `   ${chalk.gray(date)} · ${entry.provider} · Used ${entry.executionCount}x`,
+        `   ${chalk.gray(date)} · ${entry.provider} · Used ${entry.executionCount}x`
       );
       console.log();
     });
@@ -505,7 +505,7 @@ async function interactiveHistoryBrowser() {
       console.log(`\nCommands today: ${chalk.bold(stats.commandsToday)}`);
       console.log(`Commands this week: ${chalk.bold(stats.commandsThisWeek)}`);
       console.log(
-        `Commands this month: ${chalk.bold(stats.commandsThisMonth)}\n`,
+        `Commands this month: ${chalk.bold(stats.commandsThisMonth)}\n`
       );
 
       await inquirer.prompt([
@@ -606,15 +606,15 @@ async function interactiveHistoryBrowser() {
     console.log(`${chalk.bold("Prompt:")} ${entry.prompt}`);
     console.log(`${chalk.bold("Command:")} ${chalk.green(entry.command)}`);
     console.log(
-      `${chalk.bold("Provider:")} ${entry.provider}${entry.model ? ` (${entry.model})` : ""}`,
+      `${chalk.bold("Provider:")} ${entry.provider}${entry.model ? ` (${entry.model})` : ""}`
     );
     console.log(
-      `${chalk.bold("Date:")} ${new Date(entry.timestamp).toLocaleString()}`,
+      `${chalk.bold("Date:")} ${new Date(entry.timestamp).toLocaleString()}`
     );
     console.log(`${chalk.bold("Used:")} ${entry.executionCount} times`);
     console.log(`${chalk.bold("Tags:")} ${entry.tags.join(", ") || "none"}`);
     console.log(
-      `${chalk.bold("Favorite:")} ${entry.isFavorite ? "Yes ★" : "No"}`,
+      `${chalk.bold("Favorite:")} ${entry.isFavorite ? "Yes ★" : "No"}`
     );
     if (entry.category) {
       console.log(`${chalk.bold("Category:")} ${entry.category}`);
@@ -666,7 +666,7 @@ async function interactiveHistoryBrowser() {
         {
           stdio: "inherit",
           shell: true,
-        },
+        }
       );
 
       await new Promise((resolve) => {
@@ -695,9 +695,7 @@ async function interactiveHistoryBrowser() {
     } else if (commandAction === "favorite") {
       const isFavorite = historyManager.toggleFavorite(entry.id);
       console.log(
-        chalk.green(
-          `\n✓ ${isFavorite ? "Added to" : "Removed from"} favorites`,
-        ),
+        chalk.green(`\n✓ ${isFavorite ? "Added to" : "Removed from"} favorites`)
       );
       await inquirer.prompt([
         {
@@ -844,7 +842,7 @@ function displayPresetList(presets: Preset[]) {
 
         const common = preset.commonUse ? chalk.yellow("★") : " ";
         console.log(
-          `  ${common} ${difficulty} ${chalk.bold(preset.name)} - ${chalk.gray(preset.description)}`,
+          `  ${common} ${difficulty} ${chalk.bold(preset.name)} - ${chalk.gray(preset.description)}`
         );
         console.log(`     ${chalk.gray(`ID: ${preset.id}`)}`);
       });
@@ -852,8 +850,8 @@ function displayPresetList(presets: Preset[]) {
 
   console.log(
     chalk.gray(
-      "\n★ = Common use | ● = Difficulty (green=easy, yellow=medium, red=hard)",
-    ),
+      "\n★ = Common use | ● = Difficulty (green=easy, yellow=medium, red=hard)"
+    )
   );
 }
 
@@ -954,7 +952,7 @@ async function usePreset(presetId: string) {
       } catch (error) {
         console.log(
           chalk.red("\n✗ Failed to copy to clipboard:"),
-          (error as Error).message,
+          (error as Error).message
         );
       }
     }
@@ -1451,10 +1449,10 @@ async function manageCustomPresets() {
   customPresets.forEach((preset: any) => {
     console.log(`${chalk.bold(preset.name)} - ${preset.description}`);
     console.log(
-      `  Category: ${preset.category} | Used: ${preset.usageCount} times`,
+      `  Category: ${preset.category} | Used: ${preset.usageCount} times`
     );
     console.log(
-      `  Created: ${new Date(preset.createdAt).toLocaleDateString()}`,
+      `  Created: ${new Date(preset.createdAt).toLocaleDateString()}`
     );
     console.log();
   });
@@ -1468,18 +1466,33 @@ async function manageCustomPresets() {
   ]);
 }
 
-console.log(`
-${vice(
-  figlet.textSync("LLMPEG", {
-    font: "ANSI Shadow",
-    horizontalLayout: "default",
-    verticalLayout: "default",
-  }),
-)}
+// Absolute path to font inside figlet package
+const fontPath = path.resolve(
+  __dirname,
+  "../node_modules/figlet/fonts/ANSI Shadow.flf"
+);
 
-Author: Ali Torki
-Github: https://github.com/ali-master/llmpeg
-`);
+// Safely load and register font
+try {
+  const fontData = fs.readFileSync(fontPath, "utf8");
+  figlet.parseFont("ANSI Shadow", fontData);
+} catch (err) {
+  console.warn("⚠️  Could not load custom font. Falling back to default.");
+}
+
+let output;
+try {
+  output = figlet.textSync("LLMPEG", { font: "ANSI Shadow" });
+} catch (e) {
+  console.warn("❗ Custom font not found. Falling back.");
+  output = figlet.textSync("LLMPEG", { font: "Standard" });
+}
+console.log(
+  `\n${vice(output)} 
+
+  Author: Ali Torki 
+  Github: https://github.com/ali-master/llmpeg`
+);
 
 // Check if any API key is configured
 if (!configManager.hasAnyApiKey()) {


### PR DESCRIPTION
 <h2>Description:</h2>
<ul>
<li>Fixes ENOENT error when ANSI Shadow font not found by using manual parseFont()</li>
<li>Improves CLI portability (removes hardcoded absolute paths)</li>
</ul>
<h3>Tested with:</h3>
<ul>
<li>Bun + Node</li>
<li>Local and global installs</li>
</ul>